### PR TITLE
Implement HTTP Cookie-Based Auth and Logout in authRouter

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.2",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -653,6 +654,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.2",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/api/src/controllers/authController.js
+++ b/api/src/controllers/authController.js
@@ -88,8 +88,15 @@ export const loginUser = async (req, res) => {
       expiresIn: "1h",
     });
 
+    //Set HTTP-only cookie
+    res.cookie("token", token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      maxAge: 3600000,
+    });
+
     res.json({
-      token,
       user: {
         id: user.user_id,
         username: user.username,
@@ -102,6 +109,22 @@ export const loginUser = async (req, res) => {
     });
   } catch (error) {
     console.error("Error logging in:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+};
+
+export const logoutUser = async (req, res) => {
+  try {
+    res.cookie("token", "", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      expires: new Date(0),
+    });
+
+    res.status(200).json({ message: "Logged out successfully", user: null });
+  } catch (error) {
+    console.error("Error logging out:", error);
     res.status(500).json({ error: "Internal Server Error" });
   }
 };

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -3,6 +3,7 @@ import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import bodyParser from "body-parser";
+import cookieParser from "cookie-parser";
 
 import booksRouter from "./routers/booksRouter.js";
 import usersRouter from "./routers/usersRouter.js";
@@ -15,10 +16,17 @@ import apiQuotesRouter from "./routers/apiQuotesRouter.js";
 
 import reviewsRouter from "./routers/reviewsRouter.js";
 
-
 const app = express();
 
-app.use(cors());
+app.use(
+  cors({
+    origin: "http://localhost:3000",
+    credentials: true,
+    methods: ["GET", "POST", "PUT", "DELETE"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+  })
+);
+app.use(cookieParser());
 app.use(bodyParser.json());
 
 app.use("/api/searchGoogleBooks", searchRouter);
@@ -31,7 +39,6 @@ app.use("/quotes", quotesRouter);
 app.use("/api/quotes", apiQuotesRouter);
 
 app.use("/api/reviews", reviewsRouter);
-
 
 app.listen(process.env.PORT, () => {
   console.log(`API listening on port ${process.env.PORT}`);

--- a/app/app/login/page.jsx
+++ b/app/app/login/page.jsx
@@ -43,9 +43,6 @@ const Login = () => {
           userData
         );
 
-        // Assuming the response contains an authentication token (e.g., JWT)
-        localStorage.setItem("token", response.token); // Store the token for further API requests
-
         alert("Login successful!");
 
         // Redirect to homepage (or dashboard)

--- a/app/app/utils/makeRequest.js
+++ b/app/app/utils/makeRequest.js
@@ -1,11 +1,12 @@
-export const makeRequest = async (url, userData) => {
+export const makeRequest = async (url, userData, method = "POST") => {
   try {
     const response = await fetch(url, {
-      method: "POST",
+      method: method,
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(userData),
+      credentials: "include", //for cookie handling
+      body: method !== "GET" ? JSON.stringify(userData) : undefined,
     });
     const result = await response.json();
 


### PR DESCRIPTION
This PR adds HTTP-only cookie-based authentication to authRouter, securely storing tokens in cookies instead of client-side storage. A new logout endpoint clears the authentication cookie, logging out the user.

Changes:
Backend:

api/src/controllers/authController.js: Modified login to set token as HTTP-only cookie; 
added logout to clear cookie.
api/src/index.js: Initialized cookie-parser.

Frontend:
app/app/login/page.jsx: Removed client-side token storage.
app/app/utils/makeRequest.js: Updated requests to include credentials.
Dependencies:
Installed cookie-parser for handling cookies (api folder)