### PR TITLE
Replace MUI Button with Button.jsx component in ConfirmationM…

### DIFF
--- a/app/app/components/Button.module.css
+++ b/app/app/components/Button.module.css
@@ -17,7 +17,7 @@
 
 .primary {
     background-color: #d5b4b4;
-    color: #867070;
+    color: #333;
     border: 2px solid #d5b4b4;
 }
 

--- a/app/app/components/ConfirmationModal.jsx
+++ b/app/app/components/ConfirmationModal.jsx
@@ -1,46 +1,42 @@
-import { Modal, Box, Button, Typography } from "@mui/material";
+import { Modal, Box, Typography } from "@mui/material";
+import Button from "./Button";
 
 const ConformationModal = ({
-  isOpen,
-  onClose,
-  onConfirm,
-  message,
-  confirmText = "Yes",
-  cancelText = "No",
+    isOpen,
+    onClose,
+    onConfirm,
+    message,
+    confirmText = "Yes",
+    cancelText = "No",
 }) => {
-  return (
-    <Modal open={isOpen} onClose={onClose}>
-      <Box
-        sx={{
-          position: "absolute",
-          top: "50%",
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-          bgcolor: "background.paper",
-          p: 4,
-          borderRadius: 2,
-          boxShadow: 24,
-        }}
-      >
-        <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
-          {message}
-        </Typography>
-        <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-          <Button variant="contained" color="primary" onClick={onConfirm}>
-            {confirmText}
-          </Button>
-          <Button
-            variant="outlined"
-            color="secondary"
-            onClick={onClose}
-            sx={{ marginLeft: 2 }}
-          >
-            {cancelText}
-          </Button>
-        </Box>
-      </Box>
-    </Modal>
-  );
+    return (
+        <Modal open={isOpen} onClose={onClose}>
+            <Box
+                sx={{
+                    position: "absolute",
+                    top: "50%",
+                    left: "50%",
+                    transform: "translate(-50%, -50%)",
+                    bgcolor: "background.paper",
+                    p: 4,
+                    borderRadius: 2,
+                    boxShadow: 24,
+                }}
+            >
+                <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
+                    {message}
+                </Typography>
+                <Box sx={{ display: "flex", justifyContent: "center", gap: 2 }}>
+                    <Button variant="primary" onClick={onConfirm}>
+                        {confirmText}
+                    </Button>
+                    <Button variant="secondary" onClick={onClose} sx={{ marginLeft: 2 }}>
+                        {cancelText}
+                    </Button>
+                </Box>
+            </Box>
+        </Modal>
+    );
 };
 
 export default ConformationModal;


### PR DESCRIPTION
This PR replaces the Material-UI Button with the Button.jsx component in the ConfirmationModal. This change ensures better design consistency and coordination with the overall style of the LeafNotes website.

In the image below, you can see a comparison of the changes made, showcasing the before and after states. 
![h](https://github.com/user-attachments/assets/b740ed06-b521-4e55-ae0e-c30c18276d58)
